### PR TITLE
SQL_Connect handle leak

### DIFF
--- a/addons/sourcemod/scripting/mge.sp
+++ b/addons/sourcemod/scripting/mge.sp
@@ -3787,7 +3787,7 @@ void PrepareSQL() // Opens the connection to the database, and creates the table
 {
     char error[256];
 
-    if (SQL_CheckConfig(g_sDBConfig))
+    if (db == null && SQL_CheckConfig(g_sDBConfig))
         db = SQL_Connect(g_sDBConfig, true, error, sizeof(error));
 
     if (db == null)


### PR DESCRIPTION
OnConfigsExecuted calls PrepareSQL -> a new SQL connection is created every time the map loads. Handles get leaked on every 24/7 MGE server that periodically reloads the map to reduce stutter. Spotted with sm_dump_handles, which shows multiple IDatabase handles before the server is properly restarted. A naive fix checks for an existing handle before creating a new connection.